### PR TITLE
 Bump kotlin to 2.0.21, agp to 8.6.1 etc. ; fix HapticFeedback do not work on lower android versions;

### DIFF
--- a/JWheelPicker/build.gradle.kts
+++ b/JWheelPicker/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 apply(from = "publish.gradle")
 
 android {
-    namespace = "io.john6.base.jwheelpicker"
+    namespace = "io.john6.base.compose.jwheelpicker"
     compileSdk = 34
 
     defaultConfig {
@@ -39,8 +39,8 @@ android {
 }
 
 dependencies {
-    implementation("androidx.compose.material:material:1.7.0")
-    implementation("androidx.fragment:fragment-ktx:1.8.3")
+    implementation("androidx.compose.material:material:1.7.4")
+    implementation("androidx.fragment:fragment-ktx:1.8.4")
     implementation("androidx.appcompat:appcompat:1.7.0")
     implementation("com.google.android.material:material:1.12.0")
 }

--- a/JWheelPicker/src/main/kotlin/io/john6/base/compose/picker/JWheelPicker.kt
+++ b/JWheelPicker/src/main/kotlin/io/john6/base/compose/picker/JWheelPicker.kt
@@ -108,10 +108,10 @@ fun JWheelPicker(
 /**
  * iOS style data picker
  *
- * @param enableHapticFeedback 是否启用震动
- * @param confirmSelectDistanceThreshold  标识 Item 选中范围
+ * @param enableHapticFeedback vibrate using [android.view.View.performHapticFeedback]
+ * @param confirmSelectDistanceThreshold  item will be selected while item centerY in [picker center - this , picker center + this]
  * @param itemCount 可滚动的 Item 数量
- * @param itemData 通过下标获取 Item 具体数据 [JWheelPickerItemInfo]
+ * @param itemData a function which take a index param return a [JWheelPickerItemInfo]
  *
  */
 @OptIn(ExperimentalFoundationApi::class)
@@ -190,7 +190,9 @@ fun JWheelPicker(
     val performHapticFeedback = {
         if (enableHapticFeedback) {
             scope.launch {
-                localView.performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK)
+                if (!localView.performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK)) {
+                    localView.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
+                }
             }
         }
     }
@@ -305,6 +307,15 @@ fun JWheelPicker(
 
 }
 
+/**
+ * Render a Item of each Picker
+ *
+ * @param index index of this item, use this to know if this item is visible or not
+ * @param text text shows inside this item
+ * @param itemHeightDp height of this item
+ * @param textStyle text style of this item
+ * @param getLayoutInfo get this layoutInfo of this LazyList
+ */
 @Composable
 private fun VerticalWheelPickerItem(
     index: Int,
@@ -363,7 +374,7 @@ private fun HorizontalWheelPickerItem(
 }
 
 /**
- * Item 3D 效果
+ * Implementation of a 3D item, do rotationX, scaleX and translationY to this GraphicsLayer
  */
 private fun GraphicsLayerScope.render3DVerticalItemEffect(
     index: Int,

--- a/JWheelPicker/src/main/kotlin/io/john6/base/compose/picker/dialog/JBasePickerDialogFragment.kt
+++ b/JWheelPicker/src/main/kotlin/io/john6/base/compose/picker/dialog/JBasePickerDialogFragment.kt
@@ -12,15 +12,9 @@ import androidx.activity.BackEventCompat
 import androidx.activity.ComponentDialog
 import androidx.activity.OnBackPressedCallback
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.shape.CornerSize
-import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.LocalElevationOverlay
@@ -36,6 +30,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalDensity
@@ -43,13 +38,12 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowCompat
 import androidx.fragment.app.DialogFragment
+import io.john6.base.compose.jwheelpicker.R
 import io.john6.base.compose.picker.JPickerOverlayStyle
 import io.john6.base.compose.picker.JWheelPickerHelper
 import io.john6.base.compose.picker.JWheelPickerHelper.drawPickerLineOverlay
 import io.john6.base.compose.picker.JWheelPickerHelper.drawPickerRectOverlay
-import io.john6.base.jwheelpicker.R
 import jSurfaceColorAtElevation
-import onlyBottomSafeDrawing
 import android.graphics.Color as androidColor
 
 /**
@@ -134,10 +128,18 @@ abstract class JBasePickerDialogFragment : DialogFragment() {
     @Composable
     abstract fun ContentView()
 
+    /**
+     * @param title took the center slot
+     * @param confirmImgVector took the right side slot, 1 priority
+     * @param confirmImgPainter took the right side slot, 2 priority
+     * @param confirmText took the right side slot, 3 priority, never null, will be the description of the icon
+     */
     @Composable
-    internal open fun DefaultPickerHeader(
+    internal fun DefaultPickerHeader(
         title: String,
-        imageVector: ImageVector,
+        confirmImgVector: ImageVector? = null,
+        confirmImgPainter: Painter? = null,
+        confirmText: String = stringResource(android.R.string.ok),
         onSubmit: () -> Unit
     ) {
         Box(
@@ -156,7 +158,25 @@ abstract class JBasePickerDialogFragment : DialogFragment() {
                 )
             )
             IconButton(onClick = onSubmit, modifier = Modifier.align(Alignment.CenterEnd)) {
-                Icon(imageVector = imageVector, contentDescription = "Submit")
+                if (confirmImgVector != null) {
+                    Icon(
+                        imageVector = confirmImgVector,
+                        contentDescription = confirmText,
+                        tint = MaterialTheme.colors.primary
+                    )
+                } else if (confirmImgPainter != null) {
+                    Icon(
+                        painter = confirmImgPainter,
+                        contentDescription = confirmText,
+                        tint = MaterialTheme.colors.primary
+                    )
+                } else {
+                    Text(
+                        text = confirmText,
+                        style = MaterialTheme.typography.h6,
+                        color = MaterialTheme.colors.primary
+                    )
+                }
             }
         }
     }

--- a/JWheelPicker/src/main/kotlin/io/john6/base/compose/picker/dialog/date/JDateWheelPickerDialogFragment.kt
+++ b/JWheelPicker/src/main/kotlin/io/john6/base/compose/picker/dialog/date/JDateWheelPickerDialogFragment.kt
@@ -9,17 +9,15 @@ import android.view.ViewGroup
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.Send
-import androidx.compose.material.icons.filled.Send
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.SavedStateViewModelFactory
 import androidx.lifecycle.ViewModelProvider
+import io.john6.base.compose.jwheelpicker.R
 import io.john6.base.compose.picker.JDateWheelPicker
 import io.john6.base.compose.picker.JWheelPickerHelper.fragmentResultKey
 import io.john6.base.compose.picker.dialog.JBasePickerDialogFragment
@@ -83,7 +81,7 @@ open class JDateWheelPickerDialogFragment : JBasePickerDialogFragment() {
         Column(modifier = Modifier.onlyBottomSafeDrawing()) {
             DefaultPickerHeader(
                 title = getDialogTitle(title = mViewModel.requiredData.title),
-                imageVector = Icons.AutoMirrored.Filled.Send,
+                confirmImgPainter = painterResource(R.drawable.ic_done_24dp_from_j_picker),
                 onSubmit = this@JDateWheelPickerDialogFragment::onSubmit
             )
 

--- a/JWheelPicker/src/main/kotlin/io/john6/base/compose/picker/dialog/multiple/JMultiplePickerDialogFragment.kt
+++ b/JWheelPicker/src/main/kotlin/io/john6/base/compose/picker/dialog/multiple/JMultiplePickerDialogFragment.kt
@@ -7,15 +7,12 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.core.content.ContextCompat
+import androidx.compose.ui.res.painterResource
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.SavedStateViewModelFactory
 import androidx.lifecycle.ViewModelProvider
@@ -25,6 +22,7 @@ import io.john6.base.compose.picker.bean.JWheelPickerInfo
 import io.john6.base.compose.picker.bean.JWheelPickerItemInfo
 import io.john6.base.compose.picker.dialog.IJPickerAdapter
 import io.john6.base.compose.picker.dialog.JBasePickerDialogFragment
+import io.john6.base.compose.jwheelpicker.R
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -83,7 +81,7 @@ class JMultiplePickerDialogFragment : JBasePickerDialogFragment() {
         Column(modifier = Modifier.onlyBottomSafeDrawing()) {
             DefaultPickerHeader(
                 title = getDialogTitle(title = mViewModel.requiredData.title),
-                imageVector = Icons.AutoMirrored.Filled.Send,
+                confirmImgPainter = painterResource(R.drawable.ic_done_24dp_from_j_picker),
                 onSubmit = this@JMultiplePickerDialogFragment::onSubmit
             )
 

--- a/JWheelPicker/src/main/kotlin/io/john6/base/compose/picker/dialog/single/JSinglePickerDialogFragment.kt
+++ b/JWheelPicker/src/main/kotlin/io/john6/base/compose/picker/dialog/single/JSinglePickerDialogFragment.kt
@@ -3,32 +3,20 @@ package io.john6.base.compose.picker.dialog.single
 import android.os.Bundle
 import android.util.Log
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.only
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
-import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.Send
-import androidx.compose.material.icons.filled.Send
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.sp
-import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.SavedStateViewModelFactory
@@ -36,9 +24,8 @@ import androidx.lifecycle.ViewModelProvider
 import io.john6.base.compose.picker.JWheelPicker
 import io.john6.base.compose.picker.JWheelPickerHelper.fragmentResultKey
 import io.john6.base.compose.picker.bean.JWheelPickerItemInfo
-import io.john6.base.compose.picker.dialog.IJPickerAdapter
 import io.john6.base.compose.picker.dialog.JBasePickerDialogFragment
-import io.john6.base.jwheelpicker.R
+import io.john6.base.compose.jwheelpicker.R
 import onlyBottomSafeDrawing
 
 /**
@@ -113,7 +100,7 @@ open class JSinglePickerDialogFragment : JBasePickerDialogFragment() {
         Column(modifier = Modifier.onlyBottomSafeDrawing()) {
             DefaultPickerHeader(
                 title = getDialogTitle(title = mViewModel.requiredData.title),
-                imageVector = Icons.AutoMirrored.Filled.Send,
+                confirmImgPainter = painterResource(R.drawable.ic_done_24dp_from_j_picker),
                 onSubmit = this@JSinglePickerDialogFragment::onSubmit
             )
 

--- a/JWheelPicker/src/main/res/drawable/ic_done_24dp_from_j_picker.xml
+++ b/JWheelPicker/src/main/res/drawable/ic_done_24dp_from_j_picker.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M9,16.2l-3.5,-3.5c-0.39,-0.39 -1.01,-0.39 -1.4,0 -0.39,0.39 -0.39,1.01 0,1.4l4.19,4.19c0.39,0.39 1.02,0.39 1.41,0L20.3,7.7c0.39,-0.39 0.39,-1.01 0,-1.4 -0.39,-0.39 -1.01,-0.39 -1.4,0L9,16.2z"
+      android:fillColor="#e8eaed"/>
+</vector>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,6 +45,6 @@ android {
 
 dependencies {
     implementation(project(":JWheelPicker"))
-    implementation("androidx.compose.material:material:1.7.0")
-    implementation("androidx.fragment:fragment-ktx:1.8.3")
+    implementation("androidx.compose.material:material:1.7.4")
+    implementation("androidx.fragment:fragment-ktx:1.8.4")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    val agpVersion = "8.5.0"
-    val kotlinVersion = "2.0.20"
+    val agpVersion = "8.6.1"
+    val kotlinVersion = "2.0.21"
 
     id("com.android.application") version agpVersion apply false
     id("com.android.library") version agpVersion apply false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Sep 10 22:20:36 CST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Update:
- Kotlin 2.0.21
- AGP 8.6.1
- Compose Material 1.7.4
- Fragment-ktx 1.8.4

Fix:
- HapticFeedback may not work on lower Android versions

API changes:

- Namespace changed from `io.john6.base.jwheelpicker` to `io.john6.base.compose.jwheelpicker` to keep the same with package name.
- Since Compose Material removed material-icon-core from its dependencies, so I changed the default DialogHeader style, and the right slot now support both Icon and Text, which means `ImageVector`, `ImagePainter` and String (default is android.R.string.ok) are all acceptable.